### PR TITLE
Giving context to serialization

### DIFF
--- a/schematics/contrib/mongo.py
+++ b/schematics/contrib/mongo.py
@@ -20,12 +20,12 @@ class ObjectIdType(BaseType):
         self.auto_fill = auto_fill
         super(ObjectIdType, self).__init__(**kwargs)
 
-    def to_native(self, value):
+    def to_native(self, value, context=None):
         if not isinstance(value, bson.objectid.ObjectId):
             value = bson.objectid.ObjectId(unicode(value))
         return value
 
-    def to_primitive(self, value):
+    def to_primitive(self, value, context=None):
         return str(value)
 
     def validate_id(self, value):

--- a/schematics/models.py
+++ b/schematics/models.py
@@ -251,10 +251,10 @@ class Model(object):
         """
         return convert(self.__class__, raw_data, **kw)
 
-    def to_native(self, role=None):
-        return to_native(self.__class__, self, role=role)
+    def to_native(self, role=None, context=None):
+        return to_native(self.__class__, self, role=role, context=context)
 
-    def to_primitive(self, role=None):
+    def to_primitive(self, role=None, context=None):
         """Return data as it would be validated. No filtering of output unless
         role is defined.
 
@@ -262,10 +262,10 @@ class Model(object):
             Filter output by a specific role
 
         """
-        return to_primitive(self.__class__, self, role=role)
+        return to_primitive(self.__class__, self, role=role, context=context)
 
-    def serialize(self, role=None):
-        return self.to_primitive(role=role)
+    def serialize(self, role=None, context=None):
+        return self.to_primitive(role=role, context=context)
 
     def flatten(self, role=None, prefix=""):
         """

--- a/schematics/transforms.py
+++ b/schematics/transforms.py
@@ -369,14 +369,17 @@ def convert(cls, instance_or_dict, context=None, partial=True, strict=False,
     return data
 
 
-def to_native(cls, instance_or_dict, role=None, raise_error_on_role=True):
-    field_converter = lambda field, value: field.to_native(value)
+def to_native(cls, instance_or_dict, role=None, raise_error_on_role=True,
+              context=None):
+    field_converter = lambda field, value: field.to_native(value,
+                                                           context=context)
     data = export_loop(cls, instance_or_dict, field_converter,
                        role=role, raise_error_on_role=raise_error_on_role)
     return data
 
 
-def to_primitive(cls, instance_or_dict, role=None, raise_error_on_role=True):
+def to_primitive(cls, instance_or_dict, role=None, raise_error_on_role=True,
+                 context=None):
     """
     Implements serialization as a mechanism to convert ``Model`` instances into
     dictionaries keyed by field_names with the converted data as the values.
@@ -397,14 +400,17 @@ def to_primitive(cls, instance_or_dict, role=None, raise_error_on_role=True):
         This parameter enforces strict behavior which requires substructures
         to have the same role definition as their parent structures.
     """
-    field_converter = lambda field, value: field.to_primitive(value)
+    field_converter = lambda field, value: field.to_primitive(value,
+                                                              context=context)
     data = export_loop(cls, instance_or_dict, field_converter,
                        role=role, raise_error_on_role=raise_error_on_role)
     return data
 
 
-def serialize(cls, instance_or_dict, role=None, raise_error_on_role=True):
-    return to_primitive(cls, instance_or_dict, role, raise_error_on_role)
+def serialize(cls, instance_or_dict, role=None, raise_error_on_role=True,
+              context=None):
+    return to_primitive(cls, instance_or_dict, role, raise_error_on_role,
+                        context)
 
 
 
@@ -503,7 +509,7 @@ def flatten_to_dict(instance_or_dict, prefix=None, ignore_none=True):
 
 
 def flatten(cls, instance_or_dict, role=None, raise_error_on_role=True,
-            ignore_none=True, prefix=None):
+            ignore_none=True, prefix=None, context=None):
     """
     Produces a flat dictionary representation of the model.  Flat, in this
     context, means there is only one level to the dictionary.  Multiple layers
@@ -542,7 +548,8 @@ def flatten(cls, instance_or_dict, role=None, raise_error_on_role=True,
         This puts a prefix in front of the field names during flattening.
         Default: None
     """
-    field_converter = lambda field, value: field.to_primitive(value)
+    field_converter = lambda field, value: field.to_primitive(value,
+                                                              context=context)
     
     data = export_loop(cls, instance_or_dict, field_converter,
                        role=role, print_none=True)

--- a/schematics/types/base.py
+++ b/schematics/types/base.py
@@ -125,12 +125,12 @@ class BaseType(TypeMeta('BaseTypeBase', (object, ), {})):
             default = self._default()
         return default
 
-    def to_primitive(self, value):
+    def to_primitive(self, value, context=None):
         """Convert internal data to a value safe to serialize.
         """
         return value
 
-    def to_native(self, value):
+    def to_native(self, value, context=None):
         """
         Convert untrusted data to a richer Python construct.
         """
@@ -180,12 +180,12 @@ class UUIDType(BaseType):
     """A field that stores a valid UUID value.
     """
 
-    def to_native(self, value):
+    def to_native(self, value, context=None):
         if not isinstance(value, uuid.UUID):
             value = uuid.UUID(value)
         return value
 
-    def to_primitive(self, value):
+    def to_primitive(self, value, context=None):
         return str(value)
 
 
@@ -252,7 +252,7 @@ class StringType(BaseType):
 
         super(StringType, self).__init__(**kwargs)
 
-    def to_native(self, value):
+    def to_native(self, value, context=None):
         if value is None:
             return None
 
@@ -360,7 +360,7 @@ class NumberType(BaseType):
 
         super(NumberType, self).__init__(**kwargs)
 
-    def to_native(self, value):
+    def to_native(self, value, context=None):
         try:
             value = self.number_class(value)
         except (TypeError, ValueError):
@@ -424,10 +424,10 @@ class DecimalType(BaseType):
 
         super(DecimalType, self).__init__(**kwargs)
 
-    def to_primitive(self, value):
+    def to_primitive(self, value, context=None):
         return unicode(value)
 
-    def to_native(self, value):
+    def to_native(self, value, context=None):
         if not isinstance(value, decimal.Decimal):
             if not isinstance(value, basestring):
                 value = unicode(value)
@@ -458,7 +458,7 @@ class HashType(BaseType):
         'hash_hex': u"Hash value is not hexadecimal.",
     }
 
-    def to_native(self, value):
+    def to_native(self, value, context=None):
         if len(value) != self.LENGTH:
             raise ValidationError(self.messages['hash_length'])
         try:
@@ -494,7 +494,7 @@ class BooleanType(BaseType):
     TRUE_VALUES = ('True', 'true', '1')
     FALSE_VALUES = ('False', 'false', '0')
 
-    def to_native(self, value):
+    def to_native(self, value, context=None):
         if isinstance(value, basestring):
             if value in self.TRUE_VALUES:
                 value = True
@@ -520,7 +520,7 @@ class DateType(BaseType):
         self.serialized_format = self.SERIALIZED_FORMAT
         super(DateType, self).__init__(**kwargs)
 
-    def to_native(self, value):
+    def to_native(self, value, context=None):
         if isinstance(value, datetime.date):
             return value
 
@@ -529,7 +529,7 @@ class DateType(BaseType):
         except (ValueError, TypeError):
             raise ConversionError(self.messages['parse'].format(value))
 
-    def to_primitive(self, value):
+    def to_primitive(self, value, context=None):
         return value.strftime(self.serialized_format)
 
 
@@ -565,7 +565,7 @@ class DateTimeType(BaseType):
         self.serialized_format = serialized_format
         super(DateTimeType, self).__init__(**kwargs)
 
-    def to_native(self, value):
+    def to_native(self, value, context=None):
         if isinstance(value, datetime.datetime):
             return value
 
@@ -576,7 +576,7 @@ class DateTimeType(BaseType):
                 continue
         raise ConversionError(self.messages['parse'].format(value))
 
-    def to_primitive(self, value):
+    def to_primitive(self, value, context=None):
         if callable(self.serialized_format):
             return self.serialized_format(value)
         return value.strftime(self.serialized_format)
@@ -586,7 +586,7 @@ class GeoPointType(BaseType):
     """A list storing a latitude and longitude.
     """
 
-    def to_native(self, value):
+    def to_native(self, value, context=None):
         """Make sure that a geo-value is of type (x, y)
         """
         if not len(value) == 2:

--- a/schematics/types/compound.py
+++ b/schematics/types/compound.py
@@ -64,7 +64,7 @@ class ModelType(MultiType):
     def __repr__(self):
         return object.__repr__(self)[:-1] + ' for %s>' % self.model_class
 
-    def to_native(self, value):
+    def to_native(self, value, context=None):
         # We have already checked if the field is required. If it is None it
         # should continue being None
         if value is None:
@@ -82,7 +82,7 @@ class ModelType(MultiType):
         # not obviously useful
         return self.model_class(value)
 
-    def to_primitive(self, model_instance):
+    def to_primitive(self, model_instance, context=None):
         primitive_data = {}
         for field_name, field, value in model_instance.atoms():
             serialized_name = field.serialized_name or field_name
@@ -90,7 +90,8 @@ class ModelType(MultiType):
             if value is None and model_instance.allow_none(field):
                     primitive_data[serialized_name] = None
             else:
-                primitive_data[serialized_name] = field.to_primitive(value)
+                primitive_data[serialized_name] = field.to_primitive(value,
+                                                                     context)
 
         return primitive_data
 
@@ -147,10 +148,10 @@ class ListType(MultiType):
         except TypeError:
             return [value]
 
-    def to_native(self, value):
+    def to_native(self, value, context=None):
         items = self._force_list(value)
 
-        return map(self.field.to_native, items)
+        return [self.field.to_native(item, context) for item in items]
 
     def check_length(self, value):
         list_length = len(value) if value else 0
@@ -180,8 +181,8 @@ class ListType(MultiType):
         if errors:
             raise ValidationError(errors)
 
-    def to_primitive(self, value):
-        return map(self.field.to_primitive, value)
+    def to_primitive(self, value, context=None):
+        return [self.field.to_primitive(item, context) for item in value]
 
     def export_loop(self, list_instance, field_converter, 
                     role=None, print_none=False):
@@ -234,7 +235,7 @@ class DictType(MultiType):
     def model_class(self):
         return self.field.model_class
 
-    def to_native(self, value, safe=False):
+    def to_native(self, value, safe=False, context=None):
         if value == EMPTY_DICT:
             value = {}
 
@@ -243,7 +244,7 @@ class DictType(MultiType):
         if not isinstance(value, dict):
             raise ValidationError(u'Only dictionaries may be used in a DictType')
 
-        return dict((self.coerce_key(k), self.field.to_native(v))
+        return dict((self.coerce_key(k), self.field.to_native(v, context))
                     for k, v in value.iteritems())
 
     def validate_items(self, items):
@@ -257,8 +258,9 @@ class DictType(MultiType):
         if errors:
             raise ValidationError(errors)
 
-    def to_primitive(self, value):
-        return dict((unicode(k), self.field.to_primitive(v)) for k, v in value.iteritems())
+    def to_primitive(self, value, context=None):
+        return dict((unicode(k), self.field.to_primitive(v, context))
+                    for k, v in value.iteritems())
 
     def export_loop(self, dict_instance, field_converter, 
                     role=None, print_none=False):

--- a/schematics/types/serializable.py
+++ b/schematics/types/serializable.py
@@ -49,8 +49,8 @@ class Serializable(object):
     def __get__(self, object, owner):
         return self.f(object)
 
-    def to_native(self, value):
-        return self.type.to_native(value)
+    def to_native(self, value, context=None):
+        return self.type.to_native(value, context)
 
-    def to_primitive(self, value):
-        return self.type.to_primitive(value)
+    def to_primitive(self, value, context=None):
+        return self.type.to_primitive(value, context)

--- a/schematics/types/temporal.py
+++ b/schematics/types/temporal.py
@@ -45,6 +45,6 @@ class TimeStampType(DateTimeType):
             value = value.replace(tzinfo=tzlocal())
         return int(round(mktime(value.astimezone(tzutc()).timetuple())))
 
-    def to_primitive(self, value):
+    def to_primitive(self, value, context=None):
         v = TimeStampType.date_to_timestamp(value)
         return v

--- a/tests/test_serialize.py
+++ b/tests/test_serialize.py
@@ -50,7 +50,7 @@ def test_serializable_with_serializable_name():
 def test_serializable_with_custom_serializable_class():
     class PlayerIdType(LongType):
 
-        def to_primitive(self, value):
+        def to_primitive(self, value, context=None):
             return unicode(value)
 
     class Player(Model):


### PR DESCRIPTION
This adds a new 'context' keyword argument to all to_native, to_primitive, and related function so that users can pass in information that those methods need to correctly deserialize data.

For instance, suppose a hypothetical MultiLanguageString type that holds messages in many different locales. The context argument allows users to pass in a requested locale so that the MultiLanguageString can return the correct string representation. For example:

``` python
    >>> class TestModel(Model):
    ...     mls = MultiLingualStringType()
    ...

    >>> t = TestModel({'mls': {'en_US': 'Hello, world!'}})

    >>> t.to_native()
    {'mls': {u'en_US': u'Hello, world!'}}

    >>> t.to_native(context={'locale': 'en_US'})
    {'mls': u'Hello, world!'}
```
