### PR TITLE
Bumped pytest in dev-requirements to match requirements-testing

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,4 @@
-pytest==2.3.4
+pytest==2.3.5
 Sphinx==1.1.3
 coverage
 python-coveralls


### PR DESCRIPTION
dev-requirements.txt and requirements-testing.txt pin different (and exact) versions of pytest. This updates dev-requirements to pytest==2.3.5.
